### PR TITLE
Add System Service On Boot

### DIFF
--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -93,7 +93,7 @@ create_start_script() {
 EOF
 }
 
-# Install service, chooses correct init system
+# Installs system specific service
 install_service() {
         if [ "${SYSD}" = "1" ]; then
         touch ${workDir}/EaselDriver.service

--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -80,8 +80,13 @@ echo "\n\n\n" &&
 #chmod 755 run.sh &&
 
 # Allow installing on reboot
+check_init() { pidof /sbin/init && SYSD="0" || SYSD="1"; }
+
+
+
+
 while true; do
-  echo "Almost done! Do you want Easel driver to run on startup (will install to crontab) [yn]: "
+  echo "Almost done! Do you want Easel driver to run on startup (will install system service) [yn]: "
   # It's important to use `read` like this so that we can be piped into `| sh`
   read yn <&1
   case $yn in

--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -80,9 +80,18 @@ echo "\n\n\n" &&
 #chmod 755 run.sh &&
 
 # Allow installing on reboot
-check_init() { pidof /sbin/init && SYSD="0" || SYSD="1"; }
+check_init() { pidof /sbin/init && SYSD="0" || SYSD="1"; } # Return 0 if init.d and 1 if systemd
 
-
+# Create simple start script and save in easel driver folder
+create_start_script() { 
+        workDir=$(pwd)
+        touch ${workDir}/start-easel-driver.sh
+        chmod +x ${workDir}/start-easel-driver.sh
+        cat <<EOF > start-easel-driver.sh
+        #!/bin/bash
+        cd ${workDir} && /usr/bin/screen -dmS easel node iris.js
+EOF
+}
 
 
 while true; do

--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -93,6 +93,37 @@ create_start_script() {
 EOF
 }
 
+install_service() {
+        if [ "${SYSD}" = "1" ]; then
+        touch ${workDir}/EaselDriver.service
+        cat <<EOF > ${workDir}/EaselDriver.service
+[Unit]
+Description=EaselDriver systemd service unit file.
+
+[Service]
+ExecStart=/bin/bash ${workDir}/start-easel-driver.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+        sudo mv ${workDir}/EaselDriver.service /etc/systemd/system/
+        sudo systemctl daemon-reload
+        sudo systemctl enable EaselDriver.service
+        else
+        touch ${workDir}/EaselDriver.service
+        cat <<EOF > ${workDir}/EaselDriver.service
+[Unit]
+Description=EaselDriver init.d service unit file.
+
+[Service]
+ExecStart=/bin/bash ${workDir}/start-easel-driver.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+        sudo mv ${workDir}/EaselDriver.service /etc/systemd/system/
+fi
+}
 
 while true; do
   echo "Almost done! Do you want Easel driver to run on startup (will install system service) [yn]: "

--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -93,6 +93,7 @@ create_start_script() {
 EOF
 }
 
+# Install service, chooses correct init system
 install_service() {
         if [ "${SYSD}" = "1" ]; then
         touch ${workDir}/EaselDriver.service

--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -110,19 +110,41 @@ EOF
         sudo mv ${driverdir}/EaselDriver.service /etc/systemd/system/
         sudo systemctl daemon-reload
         sudo systemctl enable EaselDriver.service
-        else
-        touch ${driverdir}/EaselDriver.service
-        cat <<EOF > ${driverdir}/EaselDriver.service
-[Unit]
-Description=EaselDriver init.d service unit file.
+        else # if init.d create start/stop script enable with chkconfig
+        touch ${driverdir}/EaselDriver
+        cat <<EOF > ${driverdir}/EaselDriver
+#!/bin/bash
+# chkconfig: 2345 20 80
+# description: Serv
 
-[Service]
-ExecStart=/bin/bash ${driverdir}/run.sh
+# Source function library.
+. /etc/init.d/functions
 
-[Install]
-WantedBy=multi-user.target
+start() {
+    cd ${driverdir}
+    /usr/bin/screen -dmS easel node iris.js
+}
+
+stop() {
+    /usr/bin/screen -X -S "easel" quit
+}
+
+case "$1" in 
+    start)
+       start
+       ;;
+    stop)
+       stop
+       ;;
+    *)
+       echo "Usage: $0 {start|stop}"
+esac
+
+exit 0 
 EOF
-        sudo mv ${driverdir}/EaselDriver.service /etc/systemd/system/
+        sudo mv ${driverdir}/EaselDriver /etc/init.d/
+        sudo chkconfig --add EaselDriver
+        sudo chkconfig --level 2345 EaselDriver on
 fi
 }
 
@@ -131,7 +153,11 @@ while true; do
   # It's important to use `read` like this so that we can be piped into `| sh`
   read yn <&1
   case $yn in
-    [Yy]* ) ((crontab -l 2>>/dev/null | egrep -v '^@reboot.*easel node iris\.js') | echo "@reboot . ~/.bashrc ; cd ~/easel-driver && /usr/bin/screen -L -dmS easel node iris.js") | crontab ; echo '\nAdded to crontab (`crontab -l` to view)'; break;;
+    [Yy]* ) 
+        check_init
+        create_start_script
+        install_service
+        break;;
     [Nn]* ) break;;
     * ) echo "Please answer yes/no";;
   esac

--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -84,45 +84,45 @@ check_init() { pidof /sbin/init && SYSD="0" || SYSD="1"; } # Return 0 if init.d 
 
 # Create simple start script and save in easel driver folder
 create_start_script() { 
-        workDir=$(pwd)
-        touch ${workDir}/start-easel-driver.sh
-        chmod +x ${workDir}/start-easel-driver.sh
-        cat <<EOF > start-easel-driver.sh
+        driverdir=$(pwd)
+        touch ${driverdir}/run.sh
+        chmod +x ${driverdir}/run.sh
+        cat <<EOF > run.sh
         #!/bin/bash
-        cd ${workDir} && /usr/bin/screen -dmS easel node iris.js
+        cd ${driverdir} && /usr/bin/screen -dmS easel node iris.js
 EOF
 }
 
 # Installs system specific service
 install_service() {
         if [ "${SYSD}" = "1" ]; then
-        touch ${workDir}/EaselDriver.service
-        cat <<EOF > ${workDir}/EaselDriver.service
+        touch ${driverdir}/EaselDriver.service
+        cat <<EOF > ${driverdir}/EaselDriver.service
 [Unit]
 Description=EaselDriver systemd service unit file.
 
 [Service]
-ExecStart=/bin/bash ${workDir}/start-easel-driver.sh
+ExecStart=/bin/bash ${driverdir}/run.sh
 
 [Install]
 WantedBy=multi-user.target
 EOF
-        sudo mv ${workDir}/EaselDriver.service /etc/systemd/system/
+        sudo mv ${driverdir}/EaselDriver.service /etc/systemd/system/
         sudo systemctl daemon-reload
         sudo systemctl enable EaselDriver.service
         else
-        touch ${workDir}/EaselDriver.service
-        cat <<EOF > ${workDir}/EaselDriver.service
+        touch ${driverdir}/EaselDriver.service
+        cat <<EOF > ${driverdir}/EaselDriver.service
 [Unit]
 Description=EaselDriver init.d service unit file.
 
 [Service]
-ExecStart=/bin/bash ${workDir}/start-easel-driver.sh
+ExecStart=/bin/bash ${driverdir}/run.sh
 
 [Install]
 WantedBy=multi-user.target
 EOF
-        sudo mv ${workDir}/EaselDriver.service /etc/systemd/system/
+        sudo mv ${driverdir}/EaselDriver.service /etc/systemd/system/
 fi
 }
 


### PR DESCRIPTION
Replaced start service @reboot via crontab with init.d and systemd services.

## Add:
- function check_init() checks system for compatibility with init.d or systemd
- function create_start_script() builds simple run.sh script in <install-dir>\easel-driver\
- function install_service() installs systemd service to call run.sh or init.d script based on check_init()

## Modify:
- User prompt to enable service on boot or not, changed wording for system service

fixes #16 