### PR TITLE
change matcher for pkg file

### DIFF
--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -8,7 +8,7 @@ mkdir -p easel-driver &&
 cd easel-driver &&
 
 # Download latest Easel Driver for Mac (which we'll extract necessary components from)
-curl -L https://easel.inventables.com/downloads | perl -ne 'print $1 if /href="([^"]+EaselDriver\S+\.pkg[^"]*)/' | xargs curl -o EaselDriver.pkg &&
+curl -L https://easel.inventables.com/downloads | perl -ne 'print $1 if /href="([^"]+EaselDriver\S*\.pkg[^"]*)/' | xargs curl -o EaselDriver.pkg &&
 
 # Install p7zip to unpack xar archive, avrdude for firmware upgrades, screen to run in background
 sudo apt-get install -y p7zip-full avrdude screen &&


### PR DESCRIPTION
Current download for the mac driver does not include the version number which is expected in the regex.

Before:
```
curl -L https://easel.inventables.com/downloads | perl -ne 'print $1 if /href="([^"]+EaselDriver\S
+\.pkg[^"]*)/' | xargs curl -o EaselDriver.pkg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3364    0  3364    0     0  10447      0 --:--:-- --:--:-- --:--:-- 10447
curl: no URL specified!
```

After:
```
curl -L https://easel.inventables.com/downloads | perl -ne 'print $1 if /href="([^"]+EaselDriver\S*\.pkg[^"]*)/' | xargs curl -o EaselDriver.pkg
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3364    0  3364    0     0   8184      0 --:--:-- --:--:-- --:--:--  8184
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 22.4M  100 22.4M    0     0  4550k      0  0:00:05  0:00:05 --:--:-- 4998k
```