### PR TITLE
Two updates to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ If you want to run your CNC on a separate computer than the one you run Easel fr
 
 **macOS/Linux**
 ```sh
-# You can first install MacPorts from https://guide.macports.org/#installing.macports
-# ncat is installed via nmap, I personally installed nmap via MacPorts by running
-sudo port install nmap
+# Forward local 1438 to remote host raspberrypi.local:1438 - change raspberrypi.local to your controller's IP/hostname
+# The -fNT option causes ssh to go into the background without allocating a terminal.
+ssh -fNT -L 1438:localhost:1438 raspberrypi.local
 
-# Now port forward local 1438 to remote host raspberrypi.local:1438 - may need to adjust raspberrypi.local to your controller's IP/hostname
-ncat --sh-exec "ncat raspberrypi.local 1438" -l 1438 --keep-open
+# If you like seeing lots of output from your controller, you could try this instead:
+# ssh -t -L 1438:localhost:1438 raspberrypi.local screen -r
 ```
 
 **Windows**

--- a/README.md
+++ b/README.md
@@ -45,10 +45,8 @@ netsh interface portproxy add v4tov4 listenport=1438 listenaddress=0.0.0.0 conne
 
 ## Start on boot
 
-The shell script asks you if you want to run on boot, and if so, it will add it to your crontab. If you didn't add it initially and want to now, you can add it like so:
+The shell script asks you if you want to run on boot, and if so, it will add it to systemd. If you later want to disable the driver, you can run
 
 ```sh
-(crontab -l ; echo "@reboot cd ~/easel-driver && /usr/bin/screen -dmS easel node iris.js") | crontab
+sudo systemctl disable EaselDriver.service
 ```
-
-Ensure that iris.js is actually in ~/easel-driver, and if not, make sure to change the `cd` directory. You must cd into the directory and not just run iris.js from the directory as iris.js uses relative paths.


### PR DESCRIPTION
There are two commits in this PR. I'm not sure if either are good enough for you, but I figured I'd try to contribute since I love this package.

1)  Use ssh instead of ncat to forward ports. This obviates the need to install a package on OSX since ssh is installed out of the box. This is how I set up my system and it seems to work reliably.

2) Driver no longer launches from contrab. Update the readme to explain how to disable the driver, instead of explaining how to install it manually. Installing it manually is too complicated. Maybe a better approach is for easel-driver.sh to always install the EaselDriver.service, and not give the user the option to skip that step? Though I don't quite like that for systems that don't have system.