### PR TITLE
Fix Perl string for new version of Easel

### DIFF
--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -33,7 +33,7 @@ ln -s lib/etc etc &&
 perl -pi -e 'if (/var PLATFORMS/) { $x = chr(39); print; $_ = "\t${x}Linux${x}: {\n\t\troot: ${x}/usr/bin/avrdude${x},\n\t\texecutable: ${x}/usr/bin/avrdude${x},\n\t\tconfig: path.join(__dirname, ${x}etc/avrdude.conf${x})\n\t},\n"; }' lib/firmware_uploader.js &&
 
 # Modify the serial port code to support CP210x/CH340/CH341-based serial devices by spoofing an FTDI chip
-perl -pi -e 'if (/callback\(ports\.map\(function\(port\)/) { print << "EOF"
+perl -pi -e 'if (/callback\(ports/) { print << "EOF"
         ports.forEach(function(part, i) {
           if (this[i].manufacturer === "1a86")
             this[i].manufacturer = "FTDI";

--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -33,7 +33,7 @@ ln -s lib/etc etc &&
 perl -pi -e 'if (/var PLATFORMS/) { $x = chr(39); print; $_ = "\t${x}Linux${x}: {\n\t\troot: ${x}/usr/bin/avrdude${x},\n\t\texecutable: ${x}/usr/bin/avrdude${x},\n\t\tconfig: path.join(__dirname, ${x}etc/avrdude.conf${x})\n\t},\n"; }' lib/firmware_uploader.js &&
 
 # Modify the serial port code to support CP210x/CH340/CH341-based serial devices by spoofing an FTDI chip
-perl -pi -e 'if (/callback\(ports\)/) { print << "EOF"
+perl -pi -e 'if (/callback\(ports\.map\(function\(port\)/) { print << "EOF"
         ports.forEach(function(part, i) {
           if (this[i].manufacturer === "1a86")
             this[i].manufacturer = "FTDI";


### PR DESCRIPTION
FYI @samyk 

Easel 0.4.0 is out, and the old version of the easel driver is unsupported and thus no longer works with the website. There was a change that broke one of the perl strings, so I fixed it.

Here's a diff of the change that broke the replacer:
```diff
-        // TODO: scope for callback?
-        callback(ports);
+ // Fix for serialPort change from comName -> path
+        // Apparently the object returned from the serial
+        // port lib is also read-only
+        callback(ports.map(function(port) {
+          const clone = {};
+          for (const key of Object.getOwnPropertyNames(port)) {
+            clone[key] = port[key];
+          }
+          clone.comName = port.path;
+          return clone;
+        }));
```

After running the new perl code, the function looks like this:

```js
      function(ports) {
        // Fix for serialPort change from comName -> path
        // Apparently the object returned from the serial
        // port lib is also read-only
        ports.forEach(function(part, i) {
          if (this[i].manufacturer === "1a86")
            this[i].manufacturer = "FTDI";
          if (this[i].manufacturer === "Silicon Labs")
            this[i].manufacturer = "FTDI";
          if (this[i].vendorId === "1a86")
            this[i].vendorId = "0403";
           if (this[i].vendorId === "10c4")
            this[i].vendorId = "0403";           
        }, ports);
        callback(ports.map(function(port) {
          const clone = {};
          for (const key of Object.getOwnPropertyNames(port)) {
            clone[key] = port[key];
          }
          clone.comName = port.path;
          return clone;
        }));
      },
```

## FYI

I haven't had time to test this fix with a CNC machine yet (I will soon unless someone else can confirm), but I _assume_ it will work. Either way, master does not currently work with 0.4.0 for the ESP/FluidNC case :(