### PR TITLE
Fixing path to nvm and version issue with node-gyp

### DIFF
--- a/easel-driver.sh
+++ b/easel-driver.sh
@@ -83,8 +83,8 @@ fi &&
 echo 'shell -$SHELL' >> ~/.screenrc &&
 
 # install nodejs v18
-nvm install v12.19.0 &&
-nvm use v12.19.0 &&
+nvm install v18.20.4 &&
+nvm use v18.20.4 &&
 
 # Install the necessary node modules
 npm install &&
@@ -113,8 +113,8 @@ create_start_script() {
         cat <<EOF > run.sh
 #!/bin/bash
 . ~/.bashrc
-. ~/.nvm/nvm.sh
-nvm use 'v12.19.0'
+. ${NVM_DIR}/nvm.sh
+nvm use 'v18.20.4'
 cd ${driverdir}
 
 echo "Starting easel-driver"


### PR DESCRIPTION
This should fix the issue with node-gyp where it was trying to use the rU option which no longer exists.  This fixes it because it uses a more up to date nodejs

It should also fix the issue where the path to node.sh is sometimes incorrect in run.sh depending on the user's configuration.   Some have the file in ~/.config/nvm/nvm.sh and some have it in ~/.nvm/nvm.sh.  This change using the variable should fix that since the if statement above already determines which path is correct and store it in that variable.